### PR TITLE
Attribute Error Fix in `assign.py` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2024/11/..
+
+### `Fixed`
+
+- Converted `data[sample_id]` to a string in the `format_df` function with `assign.py` to prevent `AttributeErrors` when non-string values are in the genomic address.
+
 ## v1.0dev - [date]
 
 Initial release of phac-nml/genomic_address_service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,5 @@ Changed README format to standard DAAD README, added useage arguments.
 ### `Dependencies`
 
 ### `Deprecated`
+
+[0.1.3]: https://github.com/phac-nml/genomic_address_service/releases/tag/0.1.3

--- a/genomic_address_service/classes/assign.py
+++ b/genomic_address_service/classes/assign.py
@@ -85,7 +85,7 @@ class assign:
         self.error_samples = []
         membership = {}
         for sample_id in data:
-            address = str(data[sample_id].split(delim))
+            address = str(data[sample_id]).split(delim)
             if len(address) != num_thresholds:
                 self.error_samples.append(sample_id)
                 continue

--- a/genomic_address_service/classes/assign.py
+++ b/genomic_address_service/classes/assign.py
@@ -85,7 +85,7 @@ class assign:
         self.error_samples = []
         membership = {}
         for sample_id in data:
-            address = data[sample_id].split(delim)
+            address = str(data[sample_id].split(delim))
             if len(address) != num_thresholds:
                 self.error_samples.append(sample_id)
                 continue


### PR DESCRIPTION
This PR resolves [ISSUE12](https://github.com/phac-nml/genomic_address_service/issues/12), which caused `AttributeError`s during cluster address assignment when using 2 or fewer levels in `GAS version 0.1.2`.

The issue occurred because `data[sample_id]` values could be non-strings (e.g., floats/integers), causing an `AttributeError` when attempting to call `.split()` on these numeric types.

To fix this, cluster addresses are now converted to strings before splitting by the specified delimiterto ensure compatibility regardless of the data type inferred by pandas in the `format_df` function of the `assign.py` class.

 Cluster address assignment with 2 or fewer levels can now be run through `gas call` and has been tested locally.