### PR TITLE
STRY0018087 - Python dependency compatibility among profile_dists, genomic_address_service, and arborator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Updated many versions in `setup.py`. [PR #15](https://github.com/phac-nml/genomic_address_service/pull/45)
+- Updated many versions in `setup.py`. [PR #45](https://github.com/phac-nml/genomic_address_service/pull/45)
 
 ## [0.2.0] - 2025-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Updated many versions in `setup.py`. [PR #15](https://github.com/phac-nml/genomic_address_service/pull/45)
+
 ## [0.2.0] - 2025-05-05
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -50,14 +50,14 @@ setup(
 
     install_requires=[
         'pyarrow>=14.0.0',
-        'numba==0.59.1',
-        'numpy==1.26.4',
-        'tables==3.9.1',
+        'numba>=0.59.1,<=0.61.2',
+        'numpy>=1.26.4,<2.0.0',
+        'tables>=3.9.1',
         'six>=1.16.0',
-        'pandas==2.0.2 ',
-        'pytest==8.3.3',
-        'scipy==1.14.1',
-        'psutil==6.1.0',
+        'pandas>=2.0.2,<2.2.0',
+        'pytest>=8.3.3',
+        'scipy>=1.14.1',
+        'psutil>=6.1.0',
         'fastparquet==2023.4.0' #Will drop support of fastparquet in future versions
 
     ],


### PR DESCRIPTION
**Description**

As a pipeline developer, I would like the Python dependencies among profile_dists, genomic_address_service, and arborator to be compatible so that I can update arborator, which depends on profile_dists and genomic_address_service.

**Acceptance Criteria**

- [x] Update profile_dists to make dependencies compatible with genomic_address_service and arborator. [(PR)](https://github.com/phac-nml/profile_dists/pull/30)
- [x] Update genomic_address_service to make dependencies compatible with profile_dists and arborator. [(PR)](https://github.com/phac-nml/genomic_address_service/pull/45)
- [x] Update arborator to make dependencies compatible with profile_dists and genomic_address_service. [(PR)](https://github.com/phac-nml/arborator/pull/15)
- [ ] Release updated profile_dists.
- [ ] Release updated genomic_address_service.

**Notes**

- numba requires Python <3.12
- numpy >=2.0.0 isn't compatible with pandas<2.2, may need a numpy dtype size changed deprecation fix to upgrade
- numba has an [upcoming deprecation](https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-reflection-for-list-and-set-types) for a function being used, at least 2 versions into the future, so I maxed at 2 version from current release