### PR TITLE
Removing fastparquet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Removed
+- fastparquet support and dependency. [PR #46](https://github.com/phac-nml/genomic_address_service/pull/46)
+
 ## [0.2.0] - 2025-05-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Removed
-- fastparquet support and Python dependency. [PR #46](https://github.com/phac-nml/genomic_address_service/pull/46)
+- fastparquet support and Python dependency. [PR #47](https://github.com/phac-nml/genomic_address_service/pull/47)
 
 ## [0.2.0] - 2025-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Removed
-- fastparquet support and dependency. [PR #46](https://github.com/phac-nml/genomic_address_service/pull/46)
+- fastparquet support and Python dependency. [PR #46](https://github.com/phac-nml/genomic_address_service/pull/46)
 
 ## [0.2.0] - 2025-05-05
 

--- a/genomic_address_service/utils.py
+++ b/genomic_address_service/utils.py
@@ -5,7 +5,6 @@ import time
 import psutil
 import pandas as pd
 import numpy as np
-import fastparquet as fp
 import tables
 from numba import jit
 from numba.typed import List

--- a/setup.py
+++ b/setup.py
@@ -57,9 +57,7 @@ setup(
         'pandas==2.0.2 ',
         'pytest==8.3.3',
         'scipy==1.14.1',
-        'psutil==6.1.0',
-        'fastparquet==2023.4.0' #Will drop support of fastparquet in future versions
-
+        'psutil==6.1.0'
     ],
 
     entry_points={


### PR DESCRIPTION
Removing fastparquet as it is no longer used by GAS. This change is partly in service of improving Python dependencies here: https://github.com/phac-nml/genomic_address_service/pull/45