### PR TITLE
Removing pyarrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Removed
+- pyarrow support and Python dependency. [PR #48](https://github.com/phac-nml/genomic_address_service/pull/48)
+
 ## [0.2.0] - 2025-05-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Removed
-- pyarrow support and Python dependency. [PR #48](https://github.com/phac-nml/genomic_address_service/pull/48)
+- pyarrow support and dependency. [PR #48](https://github.com/phac-nml/genomic_address_service/pull/48)
 
 ## [0.2.0] - 2025-05-05
 

--- a/genomic_address_service/classes/neigbours.py
+++ b/genomic_address_service/classes/neigbours.py
@@ -1,7 +1,6 @@
 import os
 from numba import jit
 from numba.typed import List
-import pyarrow.parquet as pq
 
 class neighbours:
     file_path = None

--- a/genomic_address_service/utils.py
+++ b/genomic_address_service/utils.py
@@ -9,7 +9,6 @@ import fastparquet as fp
 import tables
 from numba import jit
 from numba.typed import List
-import pyarrow.parquet as pq
 import re
 import json
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
     },
 
     install_requires=[
-        'pyarrow>=14.0.0',
         'numba==0.59.1',
         'numpy==1.26.4',
         'tables==3.9.1',


### PR DESCRIPTION
Removing pyarrow as it is no longer used by GAS. This change is partly in service of improving Python dependencies here: https://github.com/phac-nml/genomic_address_service/pull/45